### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Library (KEYWORD1)
 #######################################
 
-RHT03			KEYWORD1	
-SparkFunRHT03 	KEYWORD1
+RHT03	KEYWORD1	
+SparkFunRHT03	KEYWORD1
 
 #######################################
 # Datatypes (KEYWORD1)
@@ -19,15 +19,15 @@ SparkFunRHT03 	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin                         KEYWORD2
-begin                         KEYWORD2
-update                        KEYWORD2
-tempC                         KEYWORD2
-tempF                         KEYWORD2
-humidity                      KEYWORD2
+begin	KEYWORD2
+begin	KEYWORD2
+update	KEYWORD2
+tempC	KEYWORD2
+tempF	KEYWORD2
+humidity	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-RHT_READ_INTERVAL_MS 1000    LITERAL1
+RHT_READ_INTERVAL_MS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords