### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=SparkFun Electronics <sparkfun.com>
 maintainer=SparkFun Electronics <techsupport@sparkfun.com>
 sentence=An Arduino library for interfacing with the SparkFun RHT03 (DHT22) 
 paragraph=An Arduino library for interfacing with the SparkFun RHT03 (DHT22)
-category=sensors
+category=Sensors
 url=https://github.com/sparkfun/SparkFun_RHT03_Arduino_Library
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'sensors' in library SparkFun RHT03 Arduino Library is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format